### PR TITLE
Add unit test for CheckoutController helper

### DIFF
--- a/tests/Controller/CheckoutControllerTest.php
+++ b/tests/Controller/CheckoutControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Controller\CheckoutController;
+
+class CheckoutControllerTest extends TestCase
+{
+    private function getUserStub(): object
+    {
+        return new class {
+            public function getEmail() { return 'customer@example.com'; }
+            public function getFirstname() { return 'John'; }
+            public function getLastname() { return 'Doe'; }
+            public function getStreet() { return 'Main St 1'; }
+            public function getZip() { return '12345'; }
+            public function getCity() { return 'Test City'; }
+            public function getCountryCode() { return 'US'; }
+        };
+    }
+
+    private function getController($user): CheckoutController
+    {
+        return new class($user) extends CheckoutController {
+            private $user;
+            public function __construct($user) { $this->user = $user; }
+            protected function getUser() { return $this->user; }
+            public function callFillDeliveryAddressFromCustomer($deliveryAddress)
+            {
+                return $this->fillDeliveryAddressFromCustomer($deliveryAddress);
+            }
+        };
+    }
+
+    public function testFillDeliveryAddressFromCustomerUsesUserDataWhenNull(): void
+    {
+        $user = $this->getUserStub();
+        $controller = $this->getController($user);
+
+        $result = $controller->callFillDeliveryAddressFromCustomer(null);
+
+        $expected = [
+            'email' => 'customer@example.com',
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+            'street' => 'Main St 1',
+            'zip' => '12345',
+            'city' => 'Test City',
+            'countryCode' => 'US',
+        ];
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testFillDeliveryAddressFromCustomerPreservesExistingValues(): void
+    {
+        $user = $this->getUserStub();
+        $controller = $this->getController($user);
+
+        $address = [
+            'firstname' => 'Existing',
+            'zip' => '99999',
+        ];
+
+        $result = $controller->callFillDeliveryAddressFromCustomer($address);
+
+        $this->assertSame('Existing', $result['firstname']);
+        $this->assertSame('99999', $result['zip']);
+        $this->assertSame('customer@example.com', $result['email']);
+        $this->assertSame('Doe', $result['lastname']);
+        $this->assertSame('Main St 1', $result['street']);
+        $this->assertSame('Test City', $result['city']);
+        $this->assertSame('US', $result['countryCode']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($autoload)) {
+    require $autoload;
+}


### PR DESCRIPTION
## Summary
- add bootstrap loader for tests
- add `CheckoutControllerTest` for `fillDeliveryAddressFromCustomer`

## Testing
- `phpunit -c phpunit.xml.dist tests/Controller/CheckoutControllerTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889021c71a88322ae320c923a54caa8